### PR TITLE
fix: exclude tests from production API build

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "start": "node dist/index.js",
     "migrate": "tsx src/db/migrate.ts",
     "test": "vitest run",

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/__tests__/**/*", "../../testkit/**/*"]
+}


### PR DESCRIPTION
## Summary
- Add `tsconfig.build.json` that excludes test files
- Update build script to use `tsconfig.build.json`

This fixes the Docker build which fails because test files import from `testkit/` which isn't copied into the container.

## Changes
- `apps/api/tsconfig.build.json` - excludes `src/__tests__/**/*`, `src/**/*.test.ts`, and `../../testkit/**/*`
- `apps/api/package.json` - build script now uses `-p tsconfig.build.json`